### PR TITLE
Fix repeated typo/syntax error

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -3,7 +3,7 @@
 # used to assume the roles required to access remote state in the
 # Terraform backend.
 provider "aws" {
-  default_tags = {
+  default_tags {
     tags = var.tags
   }
   region = var.aws_region
@@ -17,7 +17,7 @@ provider "aws" {
     role_arn     = data.terraform_remote_state.images_staging.outputs.provisionaccount_role.arn
     session_name = local.caller_user_name
   }
-  default_tags = {
+  default_tags {
     tags = var.tags
   }
   region = var.aws_region
@@ -31,7 +31,7 @@ provider "aws" {
     role_arn     = data.terraform_remote_state.images_production.outputs.provisionaccount_role.arn
     session_name = local.caller_user_name
   }
-  default_tags = {
+  default_tags {
     tags = var.tags
   }
   region = var.aws_region
@@ -45,7 +45,7 @@ provider "aws" {
     role_arn     = data.terraform_remote_state.images_staging_ssm.outputs.provisionparameterstorereadroles_role.arn
     session_name = local.caller_user_name
   }
-  default_tags = {
+  default_tags {
     tags = var.tags
   }
   region = var.aws_region
@@ -59,7 +59,7 @@ provider "aws" {
     role_arn     = data.terraform_remote_state.images_production_ssm.outputs.provisionparameterstorereadroles_role.arn
     session_name = local.caller_user_name
   }
-  default_tags = {
+  default_tags {
     tags = var.tags
   }
   region = var.aws_region
@@ -72,7 +72,7 @@ provider "aws" {
     role_arn     = data.terraform_remote_state.users.outputs.provisionaccount_role.arn
     session_name = local.caller_user_name
   }
-  default_tags = {
+  default_tags {
     tags = var.tags
   }
   region = var.aws_region


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a repeated typo/syntax error in the Terraform code that configures the providers.

## 💭 Motivation and context ##

As it stands, the code is incorrect and cannot be applied.

## 🧪 Testing ##

I manually applied these changes to [cisagov/ansible-role-cobalt-strike](https://github.com/cisagov/ansible-role-cobalt-strike) and verified that they fixed the error I was seeing.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
