### PR TITLE
Adjust pre-requisite language to be less COOL-centric

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,19 @@ permissions. This only needs to be run once per project, per AWS
 account. This user can also be used to run the Molecule tests on your
 local machine.
 
-Before the build user can be created, the following profile must exist in
-your AWS credentials file:
+Before the build user can be created, you will need a profile in your
+AWS credentials file that allows you to read and write your remote
+Terraform state.  (You almost certainly do not want to use local
+Terraform state for this long-lived build user.)  If the build user is
+to be created in the CISA COOL environment, for example, then you will
+need the `cool-terraform-backend` profile.
 
-- `cool-terraform-backend`
-
-The easiest way to set up that profile is to use our
+The easiest way to set up the Terraform remote state profile is to
+make use of our
 [`aws-profile-sync`](https://github.com/cisagov/aws-profile-sync)
 utility. Follow the usage instructions in that repository before
-continuing with the next steps. Note that you will need to know where
-your team stores their remote profile data in order to use
+continuing with the next steps, and note that you will need to know
+where your team stores their remote profile data in order to use
 [`aws-profile-sync`](https://github.com/cisagov/aws-profile-sync).
 
 To create the build user, follow these instructions:


### PR DESCRIPTION
## 🗣 Description ##

This pull request adjusts the language in the pre-requisite section of `README.md` to be less COOL-centric.

## 💭 Motivation and context ##

@mcdonnnj pointed out [in cisagov/ansible-role-geoip2#8](https://github.com/cisagov/ansible-role-geoip2/pull/8#discussion_r683976710) that such language is not appropriate for many of our existing Ansible roles.  It is also the case for many of our Ansible roles that, although we use them exclusively in the COOL, they could be applied elsewhere.

## 🧪 Testing ##

I proofread over the rendered Markdown output.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] All new and existing tests pass.
