### PR TITLE
Support Terraform 0.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,13 +85,6 @@ jobs:
         run: |
           go install \
             github.com/terraform-docs/terraform-docs@${TERRAFORM_DOCS_VERSION}
-      - name: Find and initialize Terraform directories
-        run: |
-          for path in $(find . -not \( -type d -name ".terraform" -prune \) \
-            -type f -iname "*.tf" -exec dirname "{}" \; | sort -u); do \
-            echo "Initializing '$path'..."; \
-            terraform init -input=false -backend=false "$path"; \
-            done
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: cisagov/setup-env-github-action@develop
+      - uses: cisagov/setup-env-github-action@improvement/support_tf_0.13
       - uses: actions/checkout@v2
       - id: setup-python
         uses: actions/setup-python@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,22 +119,7 @@ repos:
     rev: v1.50.0
     hooks:
       - id: terraform_fmt
-      # There are ongoing issues with how this command works. This issue
-      # documents the core issue:
-      # https://github.com/hashicorp/terraform/issues/21408
-      # We have seen issues primarily with proxy providers and Terraform code
-      # that uses remote state. The PR
-      # https://github.com/hashicorp/terraform/pull/24887
-      # has been approved and is part of the 0.13 release to resolve the issue
-      # with remote states.
-      # The PR
-      # https://github.com/hashicorp/terraform/pull/24896
-      # is a proprosed fix to deal with `terraform validate` with proxy
-      # providers (among other configurations).
-      # We have decided to disable the terraform_validate hook until the issues
-      # above have been resolved, which we hope will be with the release of
-      # Terraform 0.13.
-      # - id: terraform_validate
+      - id: terraform_validate
 
   # Docker hooks
   - repo: https://github.com/IamTheFij/docker-pre-commit

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,6 +1,6 @@
 terraform {
-  # We want to hold off on 0.13 or higher until we have tested it.
-  required_version = "~> 0.12.0"
+  # We want to hold off on 0.14 or higher until we have tested it.
+  required_version = "~> 0.13.0"
 
   # If you use any other providers you should also pin them to the
   # major version currently being used.  This practice will help us
@@ -9,6 +9,9 @@ terraform {
     # Version 3.38.0 of the Terraform AWS provider is the first
     # version to support default tags.
     # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
-    aws = "~> 3.38"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.38"
+    }
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR moves this skeleton from Terraform 0.12 to 0.13 and enables the `terraform validate` pre-commit hook.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We have been sitting on Terraform 0.12.x for far too long.  This PR gets us to 0.13.x, which is a step towards our goal of moving to Terraform 1.0.x and a more regular upgrade cadence.

This PR is a part of cisagov/cool-system#94 and related to the following other PRs:
* https://github.com/cisagov/setup-env-github-action/pull/37
* https://github.com/cisagov/skeleton-generic/pull/90

This PR is similar to https://github.com/cisagov/skeleton-tf-module/pull/57 and https://github.com/cisagov/skeleton-packer/pull/82.

## 🧪 Testing ##

To test this PR, I installed Terraform 0.13.7 on my local system and validated the following:
* [x] All pre-commit tests pass locally, including the newly-enabled `terraform validate` (note that I had to run `terraform init -reconfigure` to properly update the backend in the `terraform/` directory)
* [x] All GitHub actions pass for this PR
* [x] I was able to successfully `terraform apply` without any errors in the `terraform/` directory

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
