### PR TITLE
Support Terraform 0.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: cisagov/setup-env-github-action@develop
+      - uses: cisagov/setup-env-github-action@improvement/support_tf_0.14
       - uses: actions/checkout@v2
       - id: setup-python
         uses: actions/setup-python@v2

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 
 ## Terraform ##
 .terraform
+.terraform.lock.hcl

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,6 +1,6 @@
 terraform {
-  # We want to hold off on 0.14 or higher until we have tested it.
-  required_version = "~> 0.13.0"
+  # We want to hold off on 1.0 or higher until we have tested it.
+  required_version = "~> 0.14.0"
 
   # If you use any other providers you should also pin them to the
   # major version currently being used.  This practice will help us


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR moves this skeleton from Terraform 0.13 to 0.14.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is the next step in our journey of migrating Terraform to a current 1.0.x version. We previously upgraded from Terraform 0.12 to 0.13 with #24.

Note that https://github.com/cisagov/skeleton-ansible-role-with-test-user/commit/6ce798037b33b61ef66164c2bc6993dd9b49b397 adds the new Terraform provider dependency lock file to our `.gitignore` file.  There is a discussion [here](https://github.com/cisagov/cool-system-internal/discussions/39) about whether or not we should change that in the future.

This PR is a part of cisagov/cool-system#218 and related to cisagov/setup-env-github-action#39.

This PR is similar to cisagov/skeleton-tf-module#62 and cisagov/skeleton-packer#86.

When all testing has been completed with Terraform 0.14 and cisagov/setup-env-github-action#39 has been merged, https://github.com/cisagov/skeleton-ansible-role-with-test-user/commit/435ee1ccf1bff0509c0484a4cabf74bde8f88829 will be reverted in a new pull request.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test this PR, I installed Terraform 0.14.11 on my local system and validated the following:
* [x] All pre-commit tests pass locally
* [x] All GitHub actions pass for this PR
* [x] I was able to successfully `terraform apply` without any errors in the `terraform/` directory

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
