### PR TITLE
Add Dependabot ignore directive

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 ---
 
+# Any ignore directives should be uncommented in downstream projects to disable
+# Dependabot updates for the given dependency. Downstream projects will get
+# these updates when the pull request(s) in the appropriate skeleton are merged
+# and Lineage processes these changes.
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # ignore:
+    #   - dependency-name: "ansible"
+    #   - dependency-name: "ansible-lint"
 
   - package-ecosystem: "terraform"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # ignore:
-    #   - dependency-name: "ansible"
-    #   - dependency-name: "ansible-lint"
+    ignore:
+      - dependency-name: "ansible"
+      - dependency-name: "ansible-lint"
 
   - package-ecosystem: "terraform"
     directory: "/terraform"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,5 @@ updates:
     directory: "/terraform"
     schedule:
       interval: "weekly"
+    # ignore:
+    #   - dependency-name: "hashicorp/aws"

--- a/.mdl_config.yaml
+++ b/.mdl_config.yaml
@@ -48,3 +48,13 @@ MD035:
 MD046:
   # Enforce the fenced style for code blocks
   style: "fenced"
+
+# MD049/emphasis-style - Emphasis style should be consistent
+MD049:
+  # Enforce asterisks as the style to use for emphasis
+  style: "asterisk"
+
+# MD050/strong-style - Strong style should be consistent
+MD050:
+  # Enforce asterisks as the style to use for strong
+  style: "asterisk"

--- a/.mdl_config.yaml
+++ b/.mdl_config.yaml
@@ -44,7 +44,7 @@ MD035:
   # Enforce dashes for horizontal rules
   style: "---"
 
-# MD046/code-block-style Code block style
+# MD046/code-block-style - Code block style
 MD046:
   # Enforce the fenced style for code blocks
   style: "fenced"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
   # Text file hooks
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.30.0
+    rev: v0.31.1
     hooks:
       - id: markdownlint
         args:
@@ -49,7 +49,7 @@ repos:
 
   # pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit
-    rev: v2.16.0
+    rev: v2.17.0
     hooks:
       - id: validate_manifest
 
@@ -75,13 +75,13 @@ repos:
 
   # Python hooks
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.1
+    rev: 1.7.2
     hooks:
       - id: bandit
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
@@ -105,14 +105,14 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v5.3.2
+    rev: v5.4.0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.64.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,12 @@
 extends: default
 
 rules:
+  # yamllint does not like it when you comment out different parts of
+  # dictionaries in a list. You can see
+  # https://github.com/adrienverge/yamllint/issues/384 for some examples of
+  # this behavior.
+  comments-indentation: disable
+
   # yamllint doesn't like when we use yes and no for true and false,
   # but that's pretty standard in Ansible.
   truthy: disable

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,9 +28,8 @@ galaxy_info:
         - bookworm
     - name: Fedora
       versions:
-        - 32
-        - 33
         - 34
+        - 35
     - name: Ubuntu
       versions:
         - bionic

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -29,12 +29,10 @@ platforms:
     image: debian:bookworm-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora32
-    image: fedora:32
-  - name: fedora33
-    image: fedora:33
   - name: fedora34
     image: fedora:34
+  - name: fedora35
+    image: fedora:35
   - name: ubuntu18
     image: ubuntu:bionic
   - name: ubuntu20

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -57,22 +57,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora32-systemd
-    image: geerlingguy/docker-fedora32-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-  - name: fedora33-systemd
-    image: geerlingguy/docker-fedora33-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
   - name: fedora34-systemd
     image: geerlingguy/docker-fedora34-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: fedora35-systemd
+    image: geerlingguy/docker-fedora35-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -96,7 +96,7 @@ provisioner:
   name: ansible
   inventory:
     host_vars:
-      debian9_systemd:
+      debian9-systemd:
         # auto_legacy is still the default behavior until Ansible 2.12
         # is released, but Molecule overrides this and forces the use
         # of auto.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a commented out dependency ignore for hashicorp/aws. This pull request is based on #41 being merged first.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Instead of a storm of Dependabot updates for core providers like this we should have the PR only generate in the skeleton and the update get pushed down with our existing Lineage process. This ignore directive should be uncommented in downstream projects to support this approach.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. This approach has also been implemented in other skeletons with success.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
