### PR TITLE
Add Dependabot ignore directive

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,4 +37,4 @@ updates:
       interval: "weekly"
     # ignore:
     #   # Managed by cisagov/skeleton-ansible-role-with-test-user
-    #   - dependency-name: "hashicorp/aws"
+    #   - dependency-name: hashicorp/aws

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
       - dependency-name: actions/setup-python
       - dependency-name: hashicorp/setup-terraform
       - dependency-name: mxschmitt/action-tmate
+      # # Managed by cisagov/skeleton-ansible-role-with-test-user
+      # - dependency-name: aws-actions/configure-aws-credentials
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds a Dependabot ignore directive for [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials)
- Removes some unnecessary quotes from another Dependabot ignore directive

## 💭 Motivation and context ##

The [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) dependency should be managed by this repository.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
