### PR TITLE
Update hashicorp/aws requirement from ~> 3.38 to ~> 4.9

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,12 +6,18 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.38.0 of the Terraform AWS provider is the first
-    # version to support default tags.
-    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
+    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
+    # only non-breaking changes and deprecation notices are introduced. Using
+    # this version will simplify migration to the new, broken out AWS S3 bucket
+    # configuration resources. Please see
+    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
+    # for more information about the changes in v4.9 and
+    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
+    # for more information about the S3 bucket refactor.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 4.9"
     }
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the version constraint for the [Terraform AWS provider](https://github.com/hashicorp/terraform-provider-aws).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We are _quite_ behind on provider versions at this point and it behooves us to start updating so we are not left woefully behind. Some changes to v4.9 of the provider that I missed (eased some of the headaches around the refactor of S3 resources) will make it easier to manage updating to this major version.

More important is that since https://github.com/cisagov/skeleton-tf-module/pull/188 was merged there are now conflicting [Terraform AWS provider](https://github.com/hashicorp/terraform-provider-aws) versions in the `terraform/` configuration. This resolves that problem.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
