### PR TITLE
Sort inputs/outputs, add nullable key, and remove dummy SSM parameter

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,15 +1,15 @@
 output "access_key" {
-  value       = module.user.access_key
   description = "The IAM access key associated with the CI IAM user created by this module."
   sensitive   = true
+  value       = module.user.access_key
 }
 
 output "role" {
-  value       = module.user.role
   description = "The IAM role that the CI user can assume to read SSM parameters in the Images account."
+  value       = module.user.role
 }
 
 output "user" {
-  value       = module.user.user
   description = "The CI IAM user created by this module."
+  value       = module.user.user
 }

--- a/terraform/user.tf
+++ b/terraform/user.tf
@@ -8,6 +8,9 @@ module "user" {
     aws.images-ssm              = aws.images_ssm
   }
 
-  entity         = "skeleton-ansible-role-with-test-user"
-  ssm_parameters = ["/example/parameter"]
+  entity = "skeleton-ansible-role-with-test-user"
+
+  # If necessary, provide a list of SSM parameters that the test user needs to
+  # be able to read
+  # ssm_parameters = ["/example/parameter"]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,6 +6,7 @@
 
 variable "terraform_state_bucket" {
   description = "The name of the S3 bucket where Terraform state is stored."
+  nullable    = false
   type        = string
 }
 
@@ -16,17 +17,18 @@ variable "terraform_state_bucket" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
-  type        = string
-  description = "The AWS region to deploy into (e.g. us-east-1)."
   default     = "us-east-1"
+  description = "The AWS region to deploy into (e.g. us-east-1)."
+  nullable    = false
+  type        = string
 }
 
 variable "tags" {
-  type        = map(string)
-  description = "Tags to apply to all AWS resources created"
-
   default = {
     Team        = "VM Fusion - Development"
     Application = "skeleton-ansible-role-with-test-user testing"
   }
+  description = "Tags to apply to all AWS resources created"
+  nullable    = false
+  type        = map(string)
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR tidies up a few thangs:
* Sorts all input variables and outputs alphabetically
* Adds the `nullable` key to all input variables
* Replaces the dummy SSM parameter with a comment explaining how to use it

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The items above were all noticed after #182 was merged, so I wanted to strike while the iron was still hot.

> [!NOTE]
> ~This PR is blocked until https://github.com/cisagov/molecule-iam-user-tf-module/pull/62 has been merged (the linting test will fail until then as well because `ssm_parameters` is still a required input to the `molecule-iam-user-tf-module`, but it won't be after [the PR](https://github.com/cisagov/molecule-iam-user-tf-module/pull/62) is merged).~

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I applied these changes (using the testing branch from https://github.com/cisagov/molecule-iam-user-tf-module/pull/62) and confirmed that they worked correctly.
 
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are (kinda, sorta) limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Apply these changes in staging and production environments.
