### PR TITLE
Remove example code that is no longer necessary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,12 +275,7 @@ jobs:
           sudo apt-get install apparmor-utils
           sudo aa-disable /usr/sbin/unix_chkpwd
         if: ${{ startsWith(matrix.platform, 'fedora') }}
-      - # This is an example of how to pass GHA secrets to Molecule
-        # via an environment variable.  See also
-        # molecule/default/converge.yml in this repository.
-        # env:
-        #   THIRD_PARTY_BUCKET: ${{ secrets.THIRD_PARTY_BUCKET }}
-        name: Run molecule tests
+      - name: Run molecule tests
         run: >-
           molecule test
           --platform-name ${{ matrix.platform }}-${{ matrix.architecture }}

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,9 +5,3 @@
     - name: Include skeleton-ansible-role-with-test-user
       ansible.builtin.include_role:
         name: skeleton-ansible-role-with-test-user
-      # This is an example of how to pass GHA secrets to Molecule via
-      # an environment variable.  See also the "Run molecule tests"
-      # step from the .github/workflows/build.yml workflow in this
-      # repository.
-      # vars:
-      #   skeleton_with_test_user_bucket_name: "{{ lookup('env', 'THIRD_PARTY_BUCKET') }}"


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes some (commented out) example code that is no longer necessary.

## 💭 Motivation and context ##

Now that we have an SSM Parameter Store parameter containing the name of the third-party bucket it is no longer necessary to pass the third-party bucket name from the GHA workflow to the Ansible role via an environment variable.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.