### PR TITLE
Add comments suggesting what needs to be done for roles that require the third-party bucket

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,3 +5,9 @@
     - name: Include skeleton-ansible-role-with-test-user
       ansible.builtin.include_role:
         name: skeleton-ansible-role-with-test-user
+      # This is an example of passing role vars via AWS SSM Parameter
+      # Store parameters.  In particular, roles that require access to
+      # resources inside the third-party bucket will likely need the
+      # name of that bucket passed in.
+      # vars:
+      #   skeleton_bucket_name: "{{ lookup('aws_ssm', '/third_party_bucket_name') }}"

--- a/terraform/user.tf
+++ b/terraform/user.tf
@@ -9,8 +9,9 @@ module "user" {
   }
 
   entity = "skeleton-ansible-role-with-test-user"
-
-  # If necessary, provide a list of SSM parameters that the test user needs to
-  # be able to read
-  # ssm_parameters = ["/example/parameter"]
+  # If necessary, provide a list of SSM Parameter Store parameters that the test user needs to
+  # be able to read.  In particular, roles that require access to
+  # resources inside the third-party bucket will likely need to access the
+  # name of that bucket via such a parameter.
+  # ssm_parameters = ["/third_party_bucket_name"]
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds comments suggesting what needs to be done for roles that require access to resources from the third-party bucket.

## 💭 Motivation and context ##

These comments will be useful for future Ansible role developers who use this skeleton repository.  I felt the lack of these comments when working on cisagov/ansible-role-cobalt-strike#92.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.