### PR TITLE
Use newer version of Terraform AWS provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,5 @@ __pycache__
 
 ## Terraform ##
 .terraform
-.terraform.lock.hcl
 *.tfconfig
 *.tfvars

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,14 @@
+---
+formatter: markdown table
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+settings:
+  anchor: false
+  atx-closed: true
+  html: false
+  lockfile: false

--- a/terraform/.terraform-docs.yml
+++ b/terraform/.terraform-docs.yml
@@ -1,0 +1,1 @@
+../.terraform-docs.yml

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.7.0"
+  constraints = ">= 4.9.0, ~> 6.7"
+  hashes = [
+    "h1:MR1e3FM/ZMHBaUOsLJu2XIjkbogmh5q5IV/N73zGX14=",
+    "zh:3c0a256f813e5e2c1e1aa137204ad9168ebe487f6cee874af9e9c78eb300568e",
+    "zh:3c49dd75ea28395b29ba259988826b956c8adf6c0b59dd8874feb4f47bad976a",
+    "zh:3e6e3e3bfc6594f4f9e2c017ee588c5fcad394b87dd0b68a3f37cd66001f3c8c",
+    "zh:3f9b55826eeebf9b2ed448fc111d772c703e1edc6678e1bb646e66f3c3f9308f",
+    "zh:44e4ced936045ddc42d22c653a6427e7eb2b7aee918dff8438da0cb40996beb4",
+    "zh:474ab4d63918f41e8ea1cef43aeb1c719629dbf289db175c95de1431a8853ae7",
+    "zh:71b9e1d82c5ccc8d9bf72b3712c2b90722fc1f35a0f0f7a9557b9ee01971e6e2",
+    "zh:7723256d6ccc55f4000d1df8db202b02b30a7d917f5d31624c717e14ba15ea95",
+    "zh:82174836faa830aff0e47ea61d4cfbb5c97e1e944b1978f1d933acd37f584c88",
+    "zh:8e62fdc10206ba7232eec991e5a387378f2fbe47cc717b7f60eeb1df2c974514",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:be24dd2d53b224d7098e75ca432746e3420ce071189eea100aa8cbcd2498d389",
+    "zh:d27651d0e458933127ddca35a833e1a0f0ff0c131391288b3239763a2fd8f96f",
+    "zh:d33c181fff1b96bf8366e6c3d92408370b21649291e8f4d1f7e9a3fbb920fc9d",
+    "zh:edc0a0a84f85036c6d3df29d09557bd43206d9ee57b10542b484050f0f34d242",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -4,7 +4,7 @@ This directory consists of [Terraform](https://www.terraform.io/) code
 that is used to create a test user.  This test user is in turn used by
 our CI/CD pipeline to test the Ansible role.
 
-See [the overall project documentation](../README.md) for a detailed
+See the [overall project documentation](../README.md) for a detailed
 description of how this code is intended to be used.
 
 <!-- BEGIN_TF_DOCS -->

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,55 @@
+# Test User #
+
+This directory consists of [Terraform](https://www.terraform.io/) code
+that is used to create a test user.  This test user is in turn used by
+our CI/CD pipeline to test the Ansible role.
+
+See [the overall project documentation](../README.md) for a detailed
+description of how this code is intended to be used.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 1.1 |
+| aws | ~> 6.7 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | ~> 6.7 |
+| terraform | n/a |
+
+## Modules ##
+
+| Name | Source | Version |
+|------|--------|---------|
+| user | github.com/cisagov/molecule-iam-user-tf-module | n/a |
+
+## Resources ##
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [terraform_remote_state.images](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.images_ssm](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
+## Inputs ##
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
+| tags | Tags to apply to all AWS resources created | `map(string)` | ```{ "Application": "skeleton-ansible-role-with-test-user testing", "Team": "VM Fusion - Development" }``` | no |
+| terraform\_state\_bucket | The name of the S3 bucket where Terraform state is stored. | `string` | n/a | yes |
+
+## Outputs ##
+
+| Name | Description |
+|------|-------------|
+| access\_key | The IAM access key associated with the CI IAM user created by this module. |
+| role | The IAM role that the CI user can assume to read SSM parameters in the Images account. |
+| user | The CI IAM user created by this module. |
+<!-- END_TF_DOCS -->

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,6 +1,7 @@
 terraform {
-  # We want to hold off on 1.1 or higher until we have tested it.
-  required_version = "~> 1.0"
+  # Version 1.1 of Terraform is the first version to support the
+  # nullable key in variable definitions.
+  required_version = "~> 1.1"
 
   # If you use any other providers you should also pin them to the
   # major version currently being used.  This practice will help us

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -7,18 +7,11 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
-    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
-    # only non-breaking changes and deprecation notices are introduced. Using
-    # this version will simplify migration to the new, broken out AWS S3 bucket
-    # configuration resources. Please see
-    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
-    # for more information about the changes in v4.9 and
-    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
-    # for more information about the S3 bucket refactor.
+    # We have verified that our code works with version 6.7 of this
+    # Terraform provider.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.9"
+      version = "~> 6.7"
     }
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Upgrades the `terraform` code to use a newer version of the Terraform AWS provider.
- Commits the `.terraform.lock.hcl` file for more reproducible builds.
- Upgrades the required version of the `terraform` executable since we use the `nullable` attribute for Terraform variables.
- Adds a `README.md` file containing the `terraform-docs` output for the `terraform` directory.

## 💭 Motivation and context ##

We should use a modern Terraform AWS provider wherever we can; otherwise, we will get left behind.

Adding the `.terraform.lock.hcl` file is a recommended practice, and it will lead to more reproducible builds.  See [the Terraform documentation](https://developer.hashicorp.com/terraform/language/files/dependency-lock) for more details.

## 🧪 Testing ##

All automated tests pass.  I also ran `terraform apply` in the `terraform` directory for all three COOL deployments and verified that nothing changed other than the addition of the `region` attribute to the AMI objects in the outputs.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
